### PR TITLE
Fix getting username in MailSubscription model

### DIFF
--- a/dbmail/models.py
+++ b/dbmail/models.py
@@ -882,7 +882,7 @@ class MailSubscription(MailSubscriptionAbstract):
 
     def __str__(self):
         if self.user:
-            return self.user.username
+            return self.user.get_username()
         return self.address
 
 


### PR DESCRIPTION
Fix getting of username in MailSubscription model's method __str__(). 
why: https://docs.djangoproject.com/en/dev/ref/contrib/auth/#django.contrib.auth.models.User.get_username
P.S.: my first PR)